### PR TITLE
Caching Background cells for re-use with destinations sharing the same location and WAD

### DIFF
--- a/src/gridCreate.py
+++ b/src/gridCreate.py
@@ -70,6 +70,7 @@ class GridCreate:
 
         #do dests in hash order, so we only need to keep the last used hash and WAD in memory
         sorted_indices = np.argsort(destination_data['hash'])  
+        row_count = 0
 
         for row in sorted_indices:
             
@@ -80,16 +81,16 @@ class GridCreate:
             dest_pop = destination_data['inTravel'][row]
             dest_pop_leftover = 0  # for storing pop amounts that have nowhere to go within a WAD
 
-            if row % 1000 == 0:
+            if row_count % 1000 == 0:
                 #    print('.', end='', flush=True)
-                logging.info('     {} Destinations'.format(row))
+                logging.info('     {} Destinations'.format(row_count))
 
             if (dest_hash == cached_hash):  
 
                 dest_WAD = cached_WAD
                 logging.debug("Already processed a dest with an identical E/N/WAD - re-using found cells")
             else:
-                logging.debug(f"New E/N/WAD combo found - populating WAD with BG cells")
+                logging.debug("New E/N/WAD combo found - populating WAD with BG cells")
                 dest_WAD = copy.deepcopy(destination_data['WAD'][row])
                 # we use deepcopy here to start with a full copy of the wad, with zero pop count and empty location list
 
@@ -152,8 +153,10 @@ class GridCreate:
 
             if dest_pop_leftover > 0:
                 # we've been through all of our WADs and there is still undistributed population (hopefully unlikely)
-                logging.info('     Destination {} had {:.3f} unallocated population'.format(row, dest_pop_leftover))
+                #logging.info('     Destination {} had {:.3f} unallocated population'.format(row, dest_pop_leftover))
                 lost_pop += dest_pop_leftover
+            
+            row_count+= 1
 
         logging.info('\n     created - Loop count: {} in {} seconds'.format(loop_count,
                                                                             round(time.time() - initialTime, 1)))

--- a/src/gridCreate.py
+++ b/src/gridCreate.py
@@ -153,7 +153,7 @@ class GridCreate:
 
             if dest_pop_leftover > 0:
                 # we've been through all of our WADs and there is still undistributed population (hopefully unlikely)
-                #logging.info('     Destination {} had {:.3f} unallocated population'.format(row, dest_pop_leftover))
+                logging.info('     Destination {} had {:.3f} unallocated population'.format(row, dest_pop_leftover))
                 lost_pop += dest_pop_leftover
             
             row_count+= 1

--- a/src/main.py
+++ b/src/main.py
@@ -64,10 +64,11 @@ def main():
 
         # Load the Background from an Ascii grid file
         #   Optional threshold parameter selection of lowest value to use for inTravel dispersion
-        #   0 includes all data, 0.0001 should make virtually no difference but speed things up for large areas
+        #   0 includes all data, 0.0001 will speed things up for large areas, but can cause problems with dispersing population
+        #    in areas with few transport links
 
         sb.loadBackgroundFromFile('BckGrnds/' + sb.projParams.background,
-                                  threshold = 0.0001)
+                                  threshold = 0)
 
         # Load the origin csv, get max/min coords
 

--- a/src/modelRun.py
+++ b/src/modelRun.py
@@ -81,7 +81,9 @@ class ModelRun:
         self.destination_data['northings'] = []  # list of Eastings
         self.destination_data['XY'] = []
         self.destination_data['WAD'] = []
+        self.destination_data['wadStrings'] = []
         self.destination_data['LD'] = []
+        self.destination_data['hash'] = []
 
         for destdata in sb.projParams.destination_data:
 
@@ -136,7 +138,9 @@ class ModelRun:
                 self.destination_data['northings'].append(dest_N)
                 self.destination_data['XY'].append(destdata['XY'][dest])
                 self.destination_data['WAD'].append(destdata['WAD'][dest])
+                self.destination_data['wadStrings'].append(destdata['wadStrings'][dest])
                 self.destination_data['LD'].append(destdata['LD'][dest])
+                self.destination_data["hash"].append(destdata['hash'][dest])                
 
                 logging.info('\n    Dest ' + str(dest)
                              + '. E: ' + str(dest_E) + ' N: ' + str(dest_N)

--- a/src/projectParams.py
+++ b/src/projectParams.py
@@ -11,6 +11,7 @@
 import logging
 import datetime
 import math
+import hashlib
 
 # Import additional modules (which will need to be installed)
 
@@ -590,14 +591,18 @@ class ProjectParams:
                         else:
                             dest_data['LD'].append(def_LD)
 
-                    # read in the WAD data
+                    # read in the WAD data (saving the raw strings to keep for hashing and caching)
+                    dest_data["wadStrings"] = []
                     wads = []
+
                     wad_default = def_WAD.split('|')
                     for val in csvData.iloc[:, col_WAD - 1].to_list():
                         if not val:
                             wads.append(wad_default)
+                            dest_data['wadStrings'].append(def_WAD)
                         else:
                             wads.append(val.split('|'))
+                            dest_data['wadStrings'].append(val)
 
                     dest_data['WAD'] = self.convertWADs(wads)
 
@@ -606,6 +611,11 @@ class ProjectParams:
                                  + str(dest_data['WAD'][0][0]) + ' '
                                  + str(dest_data['WAD'][0][0][0]) + ' '
                                  + str(dest_data['WAD'][0][0][1]))
+
+                    #create hashes for each destination's location and WAD string (so, once we have identified the origins/bgs)
+                    dest_data["hash"] = []
+                    for idx in range(len(dest_data['eastings'])):
+                        dest_data["hash"].append(hashlib.md5("{}-{}-{}".format(dest_data['eastings'][idx], dest_data['northings'][idx], dest_data['wadStrings'][idx]).encode("utf-8")).hexdigest())
 
                     # read in the Major Flows data
                     major_flows = csvData.iloc[:, min(col_MajorFlowCols) - 1:max(col_MajorFlowCols)]

--- a/src/projectParams.py
+++ b/src/projectParams.py
@@ -612,7 +612,8 @@ class ProjectParams:
                                  + str(dest_data['WAD'][0][0][0]) + ' '
                                  + str(dest_data['WAD'][0][0][1]))
 
-                    #create hashes for each destination's location and WAD string (so, once we have identified the origins/bgs)
+                    #create hashes for each destination's location and WAD string (so, once we have identified the origins/bgs, 
+                    # we can re-use them across destinations that share the same Easting/Northing/WAD)
                     dest_data["hash"] = []
                     for idx in range(len(dest_data['eastings'])):
                         dest_data["hash"].append(hashlib.md5("{}-{}-{}".format(dest_data['eastings'][idx], dest_data['northings'][idx], dest_data['wadStrings'][idx]).encode("utf-8")).hexdigest())


### PR DESCRIPTION
When loading in the Destination files, the code now makes and stores a hash of the concatenated Easting/Northing/WAD strings, so that when creating the grid, it only needs to identify the BG cells that population should be redistributed to once for each destination that shares the same location and Wide Area Distribution.

I have tested this on the Bristol area parameters, and it speeds up the distributions for already cached destinations ~10x (roughly 10 destinations/s on uncached dests, vs ~100/s for cached dests). I haven't tested it on an england-wide model run yet, but I assume the speedups will be similar.

All unit tests pass.

Next steps:
 - Try implementing a similar caching approach for the origins around a particular destination
 - Look into moving this to a pre-processing step before running the model, so that the caches can be saved to disk and re-used across model runs