### PR TITLE
Issue with how the SB247 code loads in WADS

### DIFF
--- a/src/projectParams.py
+++ b/src/projectParams.py
@@ -597,7 +597,7 @@ class ProjectParams:
 
                     wad_default = def_WAD.split('|')
                     for val in csvData.iloc[:, col_WAD - 1].to_list():
-                        if not val:
+                        if not isinstance(val, str):
                             wads.append(wad_default)
                             dest_data['wadStrings'].append(def_WAD)
                         else:


### PR DESCRIPTION
Currently, the SB247 code crashes when trying to load in a record that doesn't have a record-specific WAD string (i.e. that field is blank in the .csv file) with a `Error loading data: 'float' object has no attribute 'split'` error. When the code finds a record without a WAD string, it should use the default value provided in the header of the Dest file, but the check for this (`if not val:`) evaluates to false even for empty WAD strings.

This issue can be reproduced by removing the wad string in the record for "Bath Spa University" in the "Data\Dests\Dest_Eng_Education_UniTaught_Term_2011.csv" file and running main.py with the default settings.

I have changed this check from `if not val:` to `if not instanceof(val, str):`, and the code now correctly identifies the empty WAD strings and uses the default WAD values.

All unit tests pass.