### PR TITLE
Allow user to choose encoding for destination and origin files

### DIFF
--- a/src/projectParams.py
+++ b/src/projectParams.py
@@ -268,12 +268,12 @@ class ProjectParams:
         logging.info('  TS Last key/category/time/weight: ' + ts_key + ' ' + category + ' '
                      + str(timekey) + ' ' + str(self.timeseries_data[ts_key][category][timekey]))
 
-    def loadOrigin(self, filename):
+    def loadOrigin(self, filename, encoding="utf-8"):
         try:
 
             with open(filename, 'r') as file_opened:
 
-                header = pd.read_csv(filename, index_col=False, header=None, nrows=23)
+                header = pd.read_csv(filename, index_col=False, header=None, nrows=23, encoding=encoding)
 
                 # identify locations of various data columns and their defaults
                 col_DataStart = int(header.iloc[3, 1])  # Start row of data
@@ -302,7 +302,7 @@ class ProjectParams:
 
                 # create a Pandas dataframe and miss out the specified header
 
-                origin_df = pd.read_csv(filename, header=[col_DataStart-1], nrows=col_DataRows, low_memory=False)
+                origin_df = pd.read_csv(filename, header=[col_DataStart-1], nrows=col_DataRows, low_memory=False, encoding=encoding)
 
                 # filter the data to within the Study area
                 # note that we include (>=) BL, and exclude (<) TR to avoid overflow
@@ -434,7 +434,7 @@ class ProjectParams:
         except IOError as e:
             logging.error(e)
 
-    def loadDestFiles(self, pathname):
+    def loadDestFiles(self, pathname, encoding="utf-8"):
 
         self.destination_data = []  # array of each destination dictionary
         total_rows = 0
@@ -450,7 +450,7 @@ class ProjectParams:
                     dest_data = {}  # empty dictionary to hold destination data
                     dest_data['Filename'] = dest_file
 
-                    header = pd.read_csv(filename, index_col=False, header=None, nrows=23)
+                    header = pd.read_csv(filename, index_col=False, header=None, nrows=23, encoding=encoding)
 
                     # identify locations of various data columns and their defaults
                     col_DataStart = int(header.iloc[3, 1])  # Start row of data
@@ -485,7 +485,7 @@ class ProjectParams:
 
                     # create a Pandas dataframe and miss out the specified header
 
-                    dest_df = pd.read_csv(filename, header=[col_DataStart-1], nrows=col_DataRows, low_memory=False)
+                    dest_df = pd.read_csv(filename, header=[col_DataStart-1], nrows=col_DataRows, low_memory=False, encoding=encoding)
 
                     # filter the data to within the Study area
                     # note that we include (>=) BL, and exclude (<) TR to avoid overflow

--- a/src/sb247.py
+++ b/src/sb247.py
@@ -166,20 +166,20 @@ class SB247:
 
         self.projParams.loadTimeSeries(self.projDir + filename)
 
-    def loadOriginFromFile(self, filename):
+    def loadOriginFromFile(self, filename, encoding="utf-8"):
 
         logging.info(SPACER + 'Loading Origin data from file: ' + self.projDir + filename + ' ...' + SPACER2)
 
-        self.projParams.loadOrigin(self.projDir + filename)
+        self.projParams.loadOrigin(self.projDir + filename, encoding=encoding)
 
-    def loadDestinationData(self, pathname):
+    def loadDestinationData(self, pathname, encoding="utf-8"):
 
         logging.info(SPACER + 'Loading Destination data...' + SPACER2)
 
         if pathname.endswith('/'):
-            self.projParams.loadDestFiles(self.projDir + pathname)
+            self.projParams.loadDestFiles(self.projDir + pathname, encoding=encoding)
         else:
-            self.projParams.loadDestFiles(self.projDir + pathname + '/')
+            self.projParams.loadDestFiles(self.projDir + pathname + '/', encoding=encoding)
 
     def runSBModel(self, ageBand, runDate, runTime,
                    destination_sample_rate = 1,


### PR DESCRIPTION
At present, when running the SB247 code on the full england Term time parameter set (`Eng_2011_v2-0_0200_TERM_Paras.txt`), it crashes with a `Error loading data: 'utf-8' codec can't decode byte 0x96 in position 31: invalid start byte` error when loading the `Dest_Eng_Education_PriSec_Term_2011.csv` destination file. This is because the school at row 12580 (`Out of School Learning Service – Central Area`) contains an en-dash in the school name, which is not in the utf-8 encoding scheme.

While it would be possible to fix this by changing that record in the destination file, it makes sense to allow files of different encodings, so I have included a new parameter to the `loadDestinationData` function to allow the user to choose the encoding that the destination files are using. I have also added that parameter to `loadORiginFromFile` even though there are no problems in the provided origin files, because it is conceivable that future origin files could contain non-utf-8 characters.

Note: if you try and run the England parameter files with this fix, the code still crashes because the school in row 24373 does not have a WAD string. This can be fixed by copying a WAD string from another school to that field, and Issue #2 fixes this issue within the code by properly allocating the default WAD to dests without a specific WAD string.

All unit tests pass.