### PR TITLE
Fix crash when logging WADS if there are no destinations in the sub-setted area of the dest file

### DIFF
--- a/src/projectParams.py
+++ b/src/projectParams.py
@@ -607,7 +607,7 @@ class ProjectParams:
                     dest_data['WAD'] = self.convertWADs(wads)
 
                     logging.info('    WADs: ' + str(dest_data['WAD'][0:5]))
-                    if len(dest_data["'WAD"] > 0):
+                    if len(dest_data["WAD"]) > 0:
                         logging.info('      First tuple/radius/percent: '
                                      + str(dest_data['WAD'][0][0]) + ' '
                                      + str(dest_data['WAD'][0][0][0]) + ' '

--- a/src/projectParams.py
+++ b/src/projectParams.py
@@ -607,10 +607,11 @@ class ProjectParams:
                     dest_data['WAD'] = self.convertWADs(wads)
 
                     logging.info('    WADs: ' + str(dest_data['WAD'][0:5]))
-                    logging.info('      First tuple/radius/percent: '
-                                 + str(dest_data['WAD'][0][0]) + ' '
-                                 + str(dest_data['WAD'][0][0][0]) + ' '
-                                 + str(dest_data['WAD'][0][0][1]))
+                    if len(dest_data["'WAD"] > 0):
+                        logging.info('      First tuple/radius/percent: '
+                                     + str(dest_data['WAD'][0][0]) + ' '
+                                     + str(dest_data['WAD'][0][0][0]) + ' '
+                                     + str(dest_data['WAD'][0][0][1]))
 
                     #create hashes for each destination's location and WAD string (so, once we have identified the origins/bgs, 
                     # we can re-use them across destinations that share the same Easting/Northing/WAD)


### PR DESCRIPTION
At present, when running the program on a study area for which one or more of the dest files has no destinations in that area, the program crashes trying to log the first WAD string of the subsetted destinations. I have added a quick check to ensure that it only tries to log this if the length of the list of WADs is greater than zero, preventing this issue from occurring.

All unit tests pass.