### PR TITLE
save separate .asc maps for each destination file

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def main():
 
         proj_dict = {
             'analysisarray': [373000, 160000, 40, 40, 200],  # BL_E, BL_N, nrows, ncols, cellsize
-            'buffer': 8000,
+            'buffer': 80000,
             'background': 'rastp6_monfri_10_16_2011.txt',
             'timeseries': 'TimeSeries.xls',
             'origin': 'Origin_Eng_OTT_2011.csv',

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def main():
 
         proj_dict = {
             'analysisarray': [373000, 160000, 40, 40, 200],  # BL_E, BL_N, nrows, ncols, cellsize
-            'buffer': 80000,
+            'buffer': 8000,
             'background': 'rastp6_monfri_10_16_2011.txt',
             'timeseries': 'TimeSeries.xls',
             'origin': 'Origin_Eng_OTT_2011.csv',

--- a/src/unit_tests.py
+++ b/src/unit_tests.py
@@ -15,6 +15,7 @@ import unittest
 import datetime
 import hashlib
 import os
+import glob
 
 from sb247 import SB247
 
@@ -243,11 +244,10 @@ class MyTestCases(unittest.TestCase):
         assert ck1 + ck2 + ck3 + ck4 + ck5 == ckall, msg
 
         # remove the files
-        os.remove(sb.projDir + 'Results/Unit_tests_dest_inTravel.asc')
-        os.remove(sb.projDir + 'Results/Unit_tests_dest_onSite_LD.asc')
-        os.remove(sb.projDir + 'Results/Unit_tests_origins_immob_LD.asc')
-        os.remove(sb.projDir + 'Results/Unit_tests_origins_remain_LD.asc')
-        os.remove(sb.projDir + 'Results/Unit_tests_results_LD.csv')
+
+        for unit_test_file in glob.glob(sb.projDir + 'Results/Unit_tests*.*'):
+            os.remove(unit_test_file)
+
 
     def file_checksum(self, filename):
         try:


### PR DESCRIPTION
Modifies model run to keep track of destinations in separate destination_data dicts, saves an output .asc file for each onSite population, then concatenates into one destination_data and creates a map for the whole onSite population. Also modified unit tests to delete all temporary files.

Note: This is kind of a kludgy way to do it, as it means that at one point the code contains the separate lists and the concatenated lists in memory at the same time, but I couldn't think of another way to do it easily, and I've tested it on a larger area (the Bath testing area with a buffer of 80k), and it doesn't seem to affect memory usage too much.

All unit tests pass.

